### PR TITLE
Cache the sqlite database made by ETE3

### DIFF
--- a/modules/local/ete_filter.nf
+++ b/modules/local/ete_filter.nf
@@ -10,28 +10,18 @@ process ETE_FILTER {
     input:
     tuple val(meta), path(fasta)
     tuple val(meta2), path(taxidmap)
-    val(taxdb_ready)
+    path(etedotdir)
 
     output:
     tuple val(meta), path("*_filtered.fasta"), emit: fasta
     tuple val(meta2), path("*_speciescodes.txt"), emit: txt
     path "versions.yml", emit: versions
 
-    when:
-    taxdb_ready == true
-
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     # Set up writable environment for ete3
     export HOME=\$PWD
-    export XDG_DATA_HOME=\$PWD/.local/share
-    export XDG_CONFIG_HOME=\$PWD/.config
-    export XDG_CACHE_HOME=\$PWD/.cache
-    
-    # Create necessary directories
-    mkdir -p .local/share .config .cache .etetoolkit
-
     rename_seqs.py --taxidmap "$taxidmap" --input "$fasta" --prefix "${prefix}"
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/local/ete_taxdb.nf
+++ b/modules/local/ete_taxdb.nf
@@ -6,8 +6,11 @@ process ETE_TAXDB {
         'https://depot.galaxyproject.org/singularity/ete3:3.1.2' :
         'quay.io/biocontainers/ete3:3.1.2' }"
 
+    input:
+    path(taxdump)
+
     output:
-    val true            , emit: ready
+    path(".etetoolkit") , emit: etedotdir
     path "versions.yml" , emit: versions
 
     when:
@@ -17,14 +20,7 @@ process ETE_TAXDB {
     """
     # Set up writable environment for ete3
     export HOME=\$PWD
-    export XDG_DATA_HOME=\$PWD/.local/share
-    export XDG_CONFIG_HOME=\$PWD/.config
-    export XDG_CACHE_HOME=\$PWD/.cache
-    
-    # Create necessary directories
-    mkdir -p .local/share .config .cache .etetoolkit
-
-    python -c "from ete3 import NCBITaxa"
+    python -c "from ete3 import NCBITaxa ; ncbi = NCBITaxa()"
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,6 +19,8 @@ params {
     blastdb_build                = '/flash/YamamotoU/Lea/hackathon/test-data/testdb.fa'
     blastdb_buildmap             = '/flash/YamamotoU/Lea/hackathon/test-data/taxid.map'
 
+    taxdump                      = null
+
     // BLASTN parameters
     blast_type                   = 'nt'
     blast_coverage               = 50

--- a/workflows/genephylo.nf
+++ b/workflows/genephylo.nf
@@ -113,10 +113,9 @@ workflow GENEPHYLO {
 		SEQKIT_RMDUP(ch_extract_out)
 		ch_rmdup = SEQKIT_RMDUP.out.fastx
 		
-		ETE_TAXDB()
-		taxdb_ready = ETE_TAXDB.out.ready
-
-		ETE_FILTER(ch_rmdup, ch_blast_out, taxdb_ready)
+		ch_taxdump = params.taxdump ? channel.value(file(params.taxdump, checkIfExists: true)) : []
+		ETE_TAXDB(ch_taxdump)
+		ETE_FILTER(ch_rmdup, ch_blast_out, ETE_TAXDB.out.etedotdir)
 		
 		ch_aln_in = ETE_FILTER.out.fasta
 


### PR DESCRIPTION
The ETE modules download the NCBI taxdump database and convert it to SQlite if not already present.  This PR ensures that this is done only once per pipeline run.  It also adds a new `--taxdump` option to provide the NCBI taxdump locally if needed.